### PR TITLE
Add test coverage on sonarqube for bugfinder

### DIFF
--- a/.github/workflows/sonarqube-build.yml
+++ b/.github/workflows/sonarqube-build.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - run: npm ci
+      - name: Unit Tests with Coverage
+        run: npm run test:unit -- --coverage --testResultsProcessor=jest-sonar-reporter
       - uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The default path for the coverage report is already `/coverage/lcov.info` so I did not specify it in sonar-project.properties

Documentation from SonarQube: https://docs.sonarqube.org/latest/analysis/test-coverage/javascript-typescript-test-coverage/