### PR TITLE
production route on container

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -9,6 +9,8 @@ http {
         root  /usr/share/nginx/html;
         include /etc/nginx/mime.types;
 
+        rewrite ^/minigames/bugfinder/(.*)$ /$1 last;
+
         location / {
             try_files $uri /index.html;
         }


### PR DESCRIPTION
Closes with other PRs Gamify-IT/issues#47

add nginx rewrite to be able to use the production route directly on the builded container